### PR TITLE
Add syntax check workflow

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -1,0 +1,13 @@
+name: AppleScript Syntax Check
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+jobs:
+  compile:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate AppleScript
+        run: osascript -l AppleScript login.scpt


### PR DESCRIPTION
## Summary
- add workflow to validate the AppleScript on macOS

## Testing
- `echo "no tests"`

------
https://chatgpt.com/codex/tasks/task_e_68401e873d34832aa4d649b85cf290d9