### PR TITLE
Fix keystroke delay comment

### DIFF
--- a/login.scpt
+++ b/login.scpt
@@ -43,7 +43,7 @@ on enterPasswordIntoVDI()
 				else
 					keystroke currentChar
 				end if
-				delay 0.1 -- half-second pause between each keystroke
+                                delay 0.1 -- short pause between each keystroke
 			end repeat
 			
 			delay 2


### PR DESCRIPTION
## Summary
- clarify the keystroke delay comment in `enterPasswordIntoVDI`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68401e85c194832a85677e2c80c41203