### PR TITLE
Remove duplicate tesseract call

### DIFF
--- a/login.scpt
+++ b/login.scpt
@@ -141,7 +141,6 @@ on OmnissaScreenshoot(stringToLookFor)
 	
 	do shell script "/opt/homebrew/bin/magick " & savePath & " -brightness-contrast 0x50 " & savePath2
 	
-	do shell script "/opt/homebrew/bin/tesseract " & savePath2 & " stdout"
 	
 	set OCROutput to do shell script "/opt/homebrew/bin/tesseract " & savePath2 & " stdout"
 	log OCROutput


### PR DESCRIPTION
## Summary
- clean up `OmnissaScreenshoot` by dropping an unused `tesseract` invocation

## Testing
- `git show -U3 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68401e8545f4832abf72872461525dd0